### PR TITLE
13 logger throws errors unless the plugin folder is named massacre

### DIFF
--- a/load.py
+++ b/load.py
@@ -2,9 +2,9 @@ import datetime
 import os
 import tkinter
 from typing import Optional
+from os.path import basename, dirname
 
 from massacre.mission_aggregation_helper import get_missions_for_all_cmdrs
-import massacre.massacre_mission_state
 
 from massacre.ui import ui
 from massacre.logger_factory import logger
@@ -43,7 +43,7 @@ def plugin_start3(_path: str) -> str:
     set_new_repo(mission_uuid_to_mission_lookup)
 
     logger.info("Awaiting CMDR Name to start building Mission Index")
-    return "massacre"
+    return basename(dirname(__file__))
 
 
 def journal_entry(cmdr: str, _is_beta: bool, _system: str,

--- a/massacre/logger_factory.py
+++ b/massacre/logger_factory.py
@@ -1,8 +1,10 @@
+from pathlib import Path
 import logging
 import os
+from os.path import basename, dirname
 import config
 
-_plugin_name = "massacre"
+_plugin_name = basename(Path(dirname(__file__)).parent)
 
 
 def __build_logger_for_module() -> logging.Logger:


### PR DESCRIPTION
Do not expect the plugin folder to be named "massacre".
The Logger would fail to start if the folder was named massacre.
Changed to make use of the parent directory name instead.

close #13 