### PR TITLE
Add overlay

### DIFF
--- a/load.py
+++ b/load.py
@@ -69,6 +69,10 @@ def journal_entry(cmdr: str, _is_beta: bool, _system: str,
         if mission_repository is not None:
             mission_repository.notify_about_mission_gone(mission_uuid)
 
+    if overlay and entry["event"] == "SendText" and entry["Message"]:
+        if entry["Message"].strip() == "!stack":
+            overlay.update_overlay()
+
 
 def plugin_prefs(parent: Any, _cmdr: str, _is_beta: bool):
     return build_settings_ui(parent)

--- a/load.py
+++ b/load.py
@@ -6,6 +6,7 @@ from os.path import basename, dirname
 from massacre.mission_aggregation_helper import get_missions_for_all_cmdrs
 
 from massacre.ui import ui
+from massacre.overlay import overlay
 from massacre.logger_factory import logger
 from massacre.massacre_settings import configuration, build_settings_ui, push_new_changes
 from massacre.version_check import build_worker
@@ -16,6 +17,8 @@ selected_cmdr: Optional[str] = None
 
 def plugin_app(parent: tkinter.Frame) -> tkinter.Frame:
     ui.set_frame(parent)
+    if overlay:
+        overlay.update_overlay()
     return parent
 
 

--- a/massacre/integrations/example.py
+++ b/massacre/integrations/example.py
@@ -21,7 +21,6 @@ class ExampleIntegrationConfig:
     """
     
     def __init__(self) -> None:
-        import massacre.massacre_settings
         self.prefix = f"{massacre_settings.plugin_name}.integrations.example"
 
 
@@ -93,7 +92,6 @@ class ExampleIntegration(Integration):
         self.__http_thread.start()
 
     def notify_can_be_activated(self) -> bool:
-        #return "The Stars didn't align :c"
         return True; # We just say this can always be activated for the sake of the example. 
 
     def notify_initialize(self):
@@ -108,8 +106,10 @@ class ExampleIntegration(Integration):
         self.__settings_temp["address"] = tk.StringVar(value=self.__config.post_address)
 
         nb.Checkbutton(frame, text="Activate Integration", variable=self.__settings_temp["active"]).grid(columnspan=2, padx=2, sticky=tk.W)
-        nb.Label(frame, text="POST Address").grid(columnspan=2, padx=2, sticky=tk.W)
-        nb.Entry(frame, textvariable=self.__settings_temp["address"]).grid(columnspan=2, padx=2, sticky=tk.W)
+        address_frame = nb.Frame(frame)
+        nb.Label(address_frame, text="POST Address").grid(column=0, row= 0, padx=2, sticky=tk.W)
+        nb.Entry(address_frame, textvariable=self.__settings_temp["address"]).grid(column=1, row=0, padx=2, sticky=tk.W)
+        address_frame.grid(sticky=tk.W)
         
     def notify_settings_finished(self) -> None:
         keys = self.__settings_temp.keys()

--- a/massacre/integrations/example.py
+++ b/massacre/integrations/example.py
@@ -1,0 +1,126 @@
+"""
+This is a basic example on how to create an Integration to Interact with EDMC-Massacre
+"""
+
+import threading
+from massacre import logger_factory, massacre_settings, ui
+from massacre.integrations.integration import Integration
+import queue
+import tkinter as tk
+import myNotebook as nb
+
+
+from theme import config
+
+
+
+class ExampleIntegrationConfig:
+    """
+    Settings for the Example Integration. 
+    Follows the same pattern as the primary config store.
+    """
+    
+    def __init__(self) -> None:
+        import massacre.massacre_settings
+        self.prefix = f"{massacre_settings.plugin_name}.integrations.example"
+
+
+    @property
+    def is_active(self) -> bool:
+        """
+        Each Integration should have some type of active-Switch and should be able to get disabled.
+        """
+        return config.get_bool(f"{self.prefix}.active", default=False)
+    
+    @is_active.setter
+    def is_active(self, val: bool):
+        config.set(f"{self.prefix}.active", val)
+
+    @property
+    def post_address(self) -> str:
+        return config.get_str(f"{self.prefix}.post_address", default="http://localhost:8000/test")
+
+    @post_address.setter
+    def post_address(self, val: str):
+        config.set(f"{self.prefix}.post_address", val)
+
+class ExampleIntegration(Integration):
+    """
+    This is a simple example integration. It creates a HTTP Thread and sends mission
+    state updates to a Server the user can specify in the Settings.
+    """
+    def __init__(self) -> None:
+        super().__init__()
+        self.is_running = False
+        self.__http_thread = None
+        self.__config = ExampleIntegrationConfig()
+        self.__message_queue = queue.Queue()
+        self.__settings_temp = {}
+        """
+        Messages to be sent to the Server. The Worker Thread will block here.
+        """
+    
+    def __worker_thread(self):
+        """
+        This does NOT run on the main thread!
+        """
+        from requests import post 
+        # Import anything that is not expected to be on every machine
+        # inside the scope of a function, not at the top.
+
+        from massacre.ui import MassacreMissionData
+        while True:
+            try:
+
+                ### Blocking 
+                entry: MassacreMissionData = self.__message_queue.get()
+
+                as_dict = {
+                    "shareable": entry.shareable_reward,
+                    "non_shareable": entry.reward,
+                    "missions": map(lambda x: x.__dict__, entry.faction_to_count_lookup.values())
+                }
+
+                post(self.__config.post_address, json=as_dict)
+
+            except Exception as ex:
+                logger_factory.logger.exception(ex)
+            
+
+    def __start_thread(self):
+        self.__http_thread = threading.Thread(target=self.__worker_thread, daemon=True, 
+                                              name="EDMC-Massacre-Integration-Example-Worker")
+        self.__http_thread.start()
+
+    def notify_can_be_activated(self) -> bool:
+        #return "The Stars didn't align :c"
+        return True; # We just say this can always be activated for the sake of the example. 
+
+    def notify_initialize(self):
+        if not self.is_running and self.__config.is_active:
+            self.__start_thread()
+
+
+
+    def notify_settings_start(self, frame) -> None:
+        self.__settings_temp.clear()
+        self.__settings_temp["active"] = tk.BooleanVar(value=self.__config.is_active)
+        self.__settings_temp["address"] = tk.StringVar(value=self.__config.post_address)
+
+        nb.Checkbutton(frame, text="Activate Integration", variable=self.__settings_temp["active"]).grid(columnspan=2, padx=2, sticky=tk.W)
+        nb.Label(frame, text="POST Address").grid(columnspan=2, padx=2, sticky=tk.W)
+        nb.Entry(frame, textvariable=self.__settings_temp["address"]).grid(columnspan=2, padx=2, sticky=tk.W)
+        
+    def notify_settings_finished(self) -> None:
+        keys = self.__settings_temp.keys()
+
+        if "active" in keys:
+            self.__config.is_active = self.__settings_temp["active"].get()
+        if "address" in keys:
+            self.__config.post_address = self.__settings_temp["address"].get()
+        
+        self.__settings_temp.clear()
+
+    def get_name(self):
+        return "Example Integration"
+

--- a/massacre/integrations/integration.py
+++ b/massacre/integrations/integration.py
@@ -1,0 +1,56 @@
+from abc import ABC, abstractmethod
+
+class Integration(ABC):
+    """
+    This is the Base Class for any Integration. EDMC-Massacre will check which 
+    Integrations can be activated on startup. 
+
+    If activation is possible, it will invoke the notify_initialize Method. 
+
+    If the User opens the settings notify_settings_start is invoked. Here the Integration 
+    can inject its own settings and commit them when notify_settings_finished is invoked. 
+    """
+
+    @abstractmethod
+    def notify_can_be_activated(_) -> bool | str:
+        """
+        This Method should tell the Plugin if this Integration could even run.
+        For example the edmcoverlay Integration needs a Python Library to be installed to function properly. 
+
+        Alternatively, this can return a reason as to why this is disabled as a string.
+        A string assumes that activation is not possible.
+        """
+        return False 
+
+    @abstractmethod
+    def notify_initialize(_) -> None:
+        """
+        Do not use the classes' constructor to initialize the Integration, as at that point we do not know yet if 
+        the Integration can be activated. Use this Method instead.
+        """
+        pass
+
+    @abstractmethod
+    def notify_settings_start(_, settings_ui) -> None:
+        """
+        Invoked by the Plugin when the user opens the settings. Add your own settings logic here.
+        """ 
+        pass
+
+    @abstractmethod
+    def notify_settings_finished(_) -> None:
+        """
+        Invoked by the Plugin when the user is done changing settings. Add settings committing logic here.
+        """
+        pass
+
+    @abstractmethod 
+    def get_name(_) -> str:
+        """
+        Returns the name of this integration. used in Logs and injected Settings
+        """
+        pass
+
+
+
+    

--- a/massacre/integrations/integration.py
+++ b/massacre/integrations/integration.py
@@ -23,7 +23,7 @@ class Integration(ABC):
         return False 
 
     @abstractmethod
-    def notify_initialize(_) -> None:
+    def notify_initialize(self) -> None:
         """
         Do not use the classes' constructor to initialize the Integration, as at that point we do not know yet if 
         the Integration can be activated. Use this Method instead.
@@ -31,26 +31,33 @@ class Integration(ABC):
         pass
 
     @abstractmethod
-    def notify_settings_start(_, settings_ui) -> None:
+    def notify_settings_start(self, settings_ui) -> None:
         """
         Invoked by the Plugin when the user opens the settings. Add your own settings logic here.
         """ 
         pass
 
     @abstractmethod
-    def notify_settings_finished(_) -> None:
+    def notify_settings_finished(self) -> None:
         """
         Invoked by the Plugin when the user is done changing settings. Add settings committing logic here.
         """
         pass
 
     @abstractmethod 
-    def get_name(_) -> str:
+    def get_name(self) -> str:
         """
         Returns the name of this integration. used in Logs and injected Settings
         """
         pass
 
+    def notify_new_event(self, event) -> None:
+        """
+        Invoked by the Plugin if there is a new Event passed from EDMC.
+
+        Note that this is intentionally note marked with @abstractmethod as not all integrations are expected to require an event
+        """
+        pass
 
 
     

--- a/massacre/integrations/main.py
+++ b/massacre/integrations/main.py
@@ -1,0 +1,79 @@
+
+
+
+import tkinter as tk
+from typing import Optional
+from massacre.integrations.integration import Integration
+import myNotebook as nb
+
+from massacre.integrations.example import ExampleIntegration
+
+__INTEGRATION_CONSTRUCTORS = [ExampleIntegration]
+"""
+Put all Integration Classes in here
+"""
+
+__ACTIVE_INSTANCES: Optional[list[Integration]] = None
+__INACTIVE_INSTANCES: Optional[list[tuple[bool, Optional[str]]]] = None
+"""
+used by get_all_active once built
+
+only None as long as not initialized
+"""
+
+def __init_state():
+    global __ACTIVE_INSTANCES
+    global __INACTIVE_INSTANCES
+    if __ACTIVE_INSTANCES is None:
+        __ACTIVE_INSTANCES = []
+        __INACTIVE_INSTANCES = []
+        for ctor in __INTEGRATION_CONSTRUCTORS:
+            instance: Integration = ctor()
+            result = instance.notify_can_be_activated()
+            if result is True:
+                instance.notify_initialize()
+                __ACTIVE_INSTANCES.append(instance)
+            elif type(result) is str:
+                __INACTIVE_INSTANCES.append((instance.get_name(), result))
+            else:
+                __INACTIVE_INSTANCES.append((instance.get_name(), None))
+
+
+
+def get_all_active() -> list[Integration]:
+    """
+    Lazy-Init Function that returns all active Integrations
+    """
+    __init_state()
+    
+    return __ACTIVE_INSTANCES
+
+
+def get_all_inactive() -> list[tuple[str, Optional[str]]]:
+    """
+    Lazy-Init Function that returns all inactive Integration with an Optional Reason
+    """
+    __init_state()
+
+    return __INACTIVE_INSTANCES
+
+
+def notify_about_settings(frame: nb.Frame):
+
+    tk.Label(frame, text="Integrations", fg="darkorange", font=("Unknown", 15)).grid(columnspan=2, padx=2, sticky=tk.W)
+
+    for integration in get_all_active():
+        tk.Label(frame, text=f":: {integration.get_name()}", font=("Unknown", 14)).grid(columnspan=2, padx=2, sticky=tk.W)
+        integration.notify_settings_start(frame)
+
+    if len(get_all_inactive()) > 0:
+        error_label_texts = []
+        for name, optional_reason in get_all_inactive():
+            reason_text = "Unknown Reason" if optional_reason is None else optional_reason
+            error_label_texts.append(f"{name} — {reason_text}")
+        error_text = "\n".join(error_label_texts)
+        tk.Label(frame, text=f"Following integrations are inactive:\n{error_text}", fg="darkorange", font=("Unknown", 10)).grid(columnspan=2, padx=2, sticky=tk.W)
+    
+def notify_about_settings_finished():
+    for integration in get_all_active():
+        integration.notify_settings_finished()

--- a/massacre/integrations/main.py
+++ b/massacre/integrations/main.py
@@ -7,14 +7,15 @@ from massacre.integrations.integration import Integration
 import myNotebook as nb
 
 from massacre.integrations.example import ExampleIntegration
+from massacre.integrations.overlay.integration import OverlayIntegration
 
-__INTEGRATION_CONSTRUCTORS = [ExampleIntegration]
+__INTEGRATION_CONSTRUCTORS = [ExampleIntegration, OverlayIntegration]
 """
 Put all Integration Classes in here
 """
 
 __ACTIVE_INSTANCES: Optional[list[Integration]] = None
-__INACTIVE_INSTANCES: Optional[list[tuple[bool, Optional[str]]]] = None
+__INACTIVE_INSTANCES: Optional[list[tuple[str, Optional[str]]]] = None
 """
 used by get_all_active once built
 
@@ -33,28 +34,25 @@ def __init_state():
             if result is True:
                 instance.notify_initialize()
                 __ACTIVE_INSTANCES.append(instance)
-            elif type(result) is str:
-                __INACTIVE_INSTANCES.append((instance.get_name(), result))
             else:
-                __INACTIVE_INSTANCES.append((instance.get_name(), None))
-
-
-
+                result_val = result if type(result) is str else None
+                __INACTIVE_INSTANCES.append((instance.get_name(), result_val))
+            
 def get_all_active() -> list[Integration]:
     """
     Lazy-Init Function that returns all active Integrations
     """
     __init_state()
-    
+    assert __ACTIVE_INSTANCES is not None
     return __ACTIVE_INSTANCES
-
+    
 
 def get_all_inactive() -> list[tuple[str, Optional[str]]]:
     """
     Lazy-Init Function that returns all inactive Integration with an Optional Reason
     """
     __init_state()
-
+    assert __INACTIVE_INSTANCES is not None
     return __INACTIVE_INSTANCES
 
 

--- a/massacre/integrations/overlay/integration.py
+++ b/massacre/integrations/overlay/integration.py
@@ -2,7 +2,8 @@ from typing import Optional
 from massacre import massacre_settings, ui
 from massacre.integrations.integration import Integration
 from massacre.integrations.overlay.overlay import Overlay
-from massacre.massacre_mission_state import massacre_mission_listeners 
+from massacre.massacre_mission_state import massacre_mission_listeners
+from massacre.logger_factory import logger
 import tkinter as tk
 import myNotebook as nb
 
@@ -62,13 +63,15 @@ class OverlayIntegration(Integration):
             import edmcoverlay # pyright: ignore
             # Intentionally unused
             # Throws Error if edmcoverlay cannot be found
+            logger.info("edmcoverlay Python-Module found")
             return True
         except:
+            logger.info("edmcoverlay Python-Module missing")
             return "edmcoverlay Python-Module missing"
 
 
     def notify_initialize(self):
-        if not self.__config.overlay_enabled and self.__overlay is not None:
+        if self.__config.overlay_enabled and self.__overlay is None:
             self.__overlay = Overlay(self.__config)
 
             def handle_new_massacre_mission_state(data: dict[int, ui.MassacreMission]):

--- a/massacre/integrations/overlay/integration.py
+++ b/massacre/integrations/overlay/integration.py
@@ -1,0 +1,115 @@
+from typing import Optional
+from massacre import massacre_settings, ui
+from massacre.integrations.integration import Integration
+from massacre.integrations.overlay.overlay import Overlay
+from massacre.massacre_mission_state import massacre_mission_listeners 
+import tkinter as tk
+import myNotebook as nb
+
+
+from theme import config
+
+class OverlayIntegrationConfig:
+    """
+    Settings for the Overlay Integration. 
+    Follows the same pattern as the primary config store.
+    """
+    
+    def __init__(self) -> None:
+        self.prefix = f"{massacre_settings.plugin_name}.integrations.overlay"
+
+
+    #######################################
+    @property
+    def overlay_enabled(self):
+        return config.get_bool(f"{self.prefix}.overlay_enabled", default=True)
+    
+    @overlay_enabled.setter
+    def overlay_enabled(self, value: bool):
+        config.set(f"{self.prefix}.overlay_enabled", value)
+    
+    #######################################
+    @property
+    def overlay_ttl(self):
+        return config.get_int(f"{self.prefix}.overlay_ttl", default=30)
+    
+    @overlay_ttl.setter
+    def overlay_ttl(self, value: int):
+        config.set(f"{self.prefix}.overlay_ttl", value)
+
+
+
+class OverlayIntegration(Integration):
+    """
+    This is the overlay integration. It interacts with the edmcoverlay Python Module
+    and sends commands to it to put data into the overlay
+    """
+    def __init__(self) -> None:
+        super().__init__()
+        self.__config = OverlayIntegrationConfig()
+        self.__settings_temp = {}
+        self.__overlay: Optional[Overlay] = None
+
+    
+
+
+    def notify_can_be_activated(self) -> bool | str:
+        """
+        Can only be activated if the Python-Module 
+        can be imported.
+        """
+        try:
+            import edmcoverlay # pyright: ignore
+            # Intentionally unused
+            # Throws Error if edmcoverlay cannot be found
+            return True
+        except:
+            return "edmcoverlay Python-Module missing"
+
+
+    def notify_initialize(self):
+        if not self.__config.overlay_enabled and self.__overlay is not None:
+            self.__overlay = Overlay(self.__config)
+
+            def handle_new_massacre_mission_state(data: dict[int, ui.MassacreMission]):
+                data_view = ui.MassacreMissionData(data)
+                if self.__overlay is not None:
+                    self.__overlay.notify_about_new_massacre_mission_state(data_view)
+            
+            massacre_mission_listeners.append(handle_new_massacre_mission_state)
+
+
+
+    def notify_settings_start(self, frame) -> None:
+        self.__settings_temp.clear()
+        self.__settings_temp["overlay_enabled"] = tk.BooleanVar(value=self.__config.overlay_enabled)
+        self.__settings_temp["overlay_ttl"] = tk.IntVar(value=self.__config.overlay_ttl)
+
+        settings_offset = 5
+
+        nb.Checkbutton(frame, text="Enable overlay", variable=self.__settings_temp["overlay_enabled"]).grid(padx=settings_offset, sticky=tk.W)
+        ttl_frame = nb.Frame(frame)
+        nb.Label(ttl_frame, text="Overlay TTL:").grid(column=0, row=0, sticky=tk.W)
+        nb.Entry(ttl_frame, textvariable=self.__settings_temp["overlay_ttl"]).grid(column=1, row=0, sticky=tk.W, padx=settings_offset)
+        ttl_frame.grid(sticky=tk.W, padx=settings_offset)
+
+
+    def notify_new_event(self, entry) -> None: 
+        if entry["event"] == "SendText" and entry["Message"]:
+            if entry["Message"].strip() == "!stack" and self.__overlay is not None:
+                self.__overlay.update_overlay()
+
+        
+    def notify_settings_finished(self) -> None:
+        keys = self.__settings_temp.keys()
+
+        if "overlay_enabled" in keys:
+            self.__config.overlay_enabled = self.__settings_temp["overlay_enabled"].get()
+        if "overlay_ttl" in keys:
+            self.__config.overlay_ttl = self.__settings_temp["overlay_ttl"].get()
+        
+        self.__settings_temp.clear()
+
+    def get_name(self):
+        return "Overlay Binding"
+

--- a/massacre/integrations/overlay/overlay.py
+++ b/massacre/integrations/overlay/overlay.py
@@ -58,7 +58,7 @@ def _display_waiting_for_missions():
 class Overlay:
     def _create_overlay(self):
         self.__overlay = None
-        if self.__config.use_overlay:
+        if self.__config.overlay_enabled:
             try:
                 import edmcoverlay # pyright: ignore
                 self.__overlay = edmcoverlay.Overlay()
@@ -107,7 +107,7 @@ class Overlay:
                                         'green',
                                         0,
                                         line_y,
-                                        ttl=self.__config.ttl)
+                                        ttl=self.__config.overlay_ttl)
             line_y+=20
         
         logger.info("Overlay Update done")

--- a/massacre/integrations/overlay/overlay.py
+++ b/massacre/integrations/overlay/overlay.py
@@ -1,21 +1,11 @@
 from typing import Optional
 
-import massacre.massacre_settings
-from massacre.massacre_mission_state import massacre_mission_listeners, MassacreMission
-from massacre.massacre_settings import Configuration
 from massacre.logger_factory import logger
 from massacre.ui import MassacreMissionData
 
-class GridOverlaySettings:
-    """
-    Subset of the entire Configuration that focuses on which information is displayed
-    """
-    def __init__(self, config: Configuration):
-        self.use_overlay = config.overlay_enabled
-        self.overlay_ttl = config.overlay_ttl
 
 
-def __display_data_header(settings: GridOverlaySettings):
+def __display_data_header():
     """
     Display the Labels of the Table
     """
@@ -25,8 +15,7 @@ def __display_data_header(settings: GridOverlaySettings):
     return overlay_elements
 
 
-def __display_row(faction: str, data: MassacreMissionData.FactionState, max_count: int,
-                  settings: GridOverlaySettings, second_largest_count: int):
+def __display_row(faction: str, data: MassacreMissionData.FactionState):
     """
     Draw one Data-Row for the Table
     """
@@ -37,7 +26,7 @@ def __display_row(faction: str, data: MassacreMissionData.FactionState, max_coun
 
     return overlay_elements
 
-def __display_sum(data: MassacreMissionData, _settings: GridOverlaySettings):
+def __display_sum(data: MassacreMissionData):
     """
     Display the Sum-Row containing the Reward-Sum and the amount of Kills required.
     """
@@ -48,14 +37,14 @@ def __display_sum(data: MassacreMissionData, _settings: GridOverlaySettings):
     reward_sum = f"{reward_sum_normal} ({reward_sum_wing})"
     return [f'{kill_sum:5}', f'{reward_sum:{len("Reward (Wing)")}}', f'{"Sum":15}']
 
-def _display_data(data: MassacreMissionData, settings: GridOverlaySettings):
+def _display_data(data: MassacreMissionData):
     lines = []
-    lines.append('|'.join(__display_data_header(settings)))
+    lines.append('|'.join(__display_data_header()))
 
-    lines.append('|'.join(__display_sum(data, settings)))
+    lines.append('|'.join(__display_sum(data)))
 
     for faction in sorted(data.faction_to_count_lookup.keys()):
-        lines.append('|'.join(__display_row(faction, data.faction_to_count_lookup[faction], data.stack_height, settings, data.before_stack_height)))
+        lines.append('|'.join(__display_row(faction, data.faction_to_count_lookup[faction])))
 
     lines.extend(data.warnings)
 
@@ -69,24 +58,22 @@ def _display_waiting_for_missions():
 class Overlay:
     def _create_overlay(self):
         self.__overlay = None
-        if self.__settings.use_overlay:
+        if self.__config.use_overlay:
             try:
-                import edmcoverlay
+                import edmcoverlay # pyright: ignore
                 self.__overlay = edmcoverlay.Overlay()
             except ModuleNotFoundError:
                 logger.warning("Overlay library could not be loaded.")
                 
-    def __init__(self):
+    def __init__(self, config):
+        self.__config = config
         self.__data: Optional[MassacreMissionData] = None
-        self.__settings: GridOverlaySettings = GridOverlaySettings(massacre.massacre_settings.configuration)
         self._create_overlay()
-        massacre.massacre_settings.configuration.config_changed_listeners.append(self.rebuild_settings)
                 
     def __bool__(self):
         return self.__overlay != None
 
-    def rebuild_settings(self, config: Configuration):
-        self.__settings = GridOverlaySettings(config)
+    def rebuild_settings(self):
         self._create_overlay()
         self.update_overlay()
     
@@ -95,7 +82,6 @@ class Overlay:
         self.update_overlay()
 
     def notify_about_settings_changed(self):
-        self.__settings: GridOverlaySettings = GridOverlaySettings(massacre.massacre_settings.configuration)
         self._create_overlay()
         self.update_overlay()
 
@@ -112,7 +98,7 @@ class Overlay:
         elif self.__data.target_sum == 0:
             lines = _display_waiting_for_missions()
         else:
-            lines = _display_data(self.__data, self.__settings)
+            lines = _display_data(self.__data)
 
         line_y = 0
         for line in lines:
@@ -121,17 +107,12 @@ class Overlay:
                                         'green',
                                         0,
                                         line_y,
-                                        ttl=self.__settings.overlay_ttl)
+                                        ttl=self.__config.ttl)
             line_y+=20
         
         logger.info("Overlay Update done")
 
-overlay = Overlay()
 
 
-def handle_new_massacre_mission_state(data: dict[int, MassacreMission]):
-    data_view = MassacreMissionData(data)
-    overlay.notify_about_new_massacre_mission_state(data_view)
 
 
-massacre_mission_listeners.append(handle_new_massacre_mission_state)

--- a/massacre/massacre_mission_state.py
+++ b/massacre/massacre_mission_state.py
@@ -65,9 +65,9 @@ massacre_mission_listeners: list[Callable[[dict[int, MassacreMission]], None]] =
 _massacre_mission_store: dict[int, MassacreMission] = {}
 
 
-def __is_mission_a_massacre_mission(name: str) -> bool:
+def __is_mission_a_massacre_mission(name: str, target_type: str) -> bool:
     """This is the filter-Function defining if a Mission is considered a Massacre-Mission"""
-    return name.startswith("Mission_Massacre") and "OnFoot" not in name
+    return name.startswith("Mission_Massacre") and "OnFoot" not in name and target_type
 
 
 def __handle_new_missions_state(data: dict[int, dict]):
@@ -81,7 +81,7 @@ def __handle_new_missions_state(data: dict[int, dict]):
     logger.info(f"Received a new Missions State with {len(data)} Missions.")
     relevant_mission_events = []
     for mission in data.values():
-        if __is_mission_a_massacre_mission(mission["Name"]):
+        if __is_mission_a_massacre_mission(mission["Name"], mission.get('TargetType', None)):
             relevant_mission_events.append(mission)
     logger.info(f"{len(relevant_mission_events)} of found Missions are Massacre Missions")
     relevant_missions = map(__build_from_event, relevant_mission_events)

--- a/massacre/massacre_settings.py
+++ b/massacre/massacre_settings.py
@@ -62,16 +62,25 @@ class Configuration:
     @display_first_user_help.setter
     def display_first_user_help(self, value: bool):
         config.set(f"{self.plugin_name}.display_first_user_help", value)
-
+    
     #######################################
     @property
-    def display_use_overlay(self):
-        return config.get_bool(f"{self.plugin_name}.display_use_overlay", default=True)
-
-    @display_use_overlay.setter
-    def display_use_overlay(self, value: bool):
-        config.set(f"{self.plugin_name}.display_use_overlay", value)
-
+    def overlay_enabled(self):
+        return config.get_bool(f"{self.plugin_name}.overlay_enabled", default=True)
+    
+    @overlay_enabled.setter
+    def overlay_enabled(self, value: bool):
+        config.set(f"{self.plugin_name}.overlay_enabled", value)
+    
+    #######################################
+    @property
+    def overlay_ttl(self):
+        return config.get_int(f"{self.plugin_name}.overlay_ttl", default=30)
+    
+    @overlay_ttl.setter
+    def overlay_ttl(self, value: int):
+        config.set(f"{self.plugin_name}.overlay_ttl", value)
+    
     #######################################
     def __init__(self):
         self.plugin_name = os.path.basename(os.path.dirname(__file__))
@@ -88,8 +97,10 @@ class Configuration:
             self.display_sum_row = data["display_sum_row"].get()
         if "display_ratio_and_cr_per_kill_row" in keys:
             self.display_ratio_and_cr_per_kill_row = data["display_ratio_and_cr_per_kill_row"].get()
-        if "display_use_overlay" in keys:
-            self.display_use_overlay = data["display_use_overlay"].get()
+        if "overlay_enabled" in keys:
+            self.overlay_enabled = data["overlay_enabled"].get()
+        if "overlay_ttl" in keys:
+            self.overlay_ttl = data['overlay_ttl'].get()
 
         for listener in self.config_changed_listeners:
             listener(self)
@@ -129,8 +140,10 @@ def build_settings_ui(root: nb.Notebook) -> tk.Frame:
         tk.IntVar(value=configuration.display_sum_row)
     __setting_changes["display_ratio_and_cr_per_kill_row"] = \
         tk.IntVar(value=configuration.display_ratio_and_cr_per_kill_row)
-    __setting_changes["display_use_overlay"] = \
-        tk.IntVar(value=configuration.display_use_overlay)
+    __setting_changes["overlay_enabled"] = \
+        tk.IntVar(value=configuration.overlay_enabled)
+    __setting_changes["overlay_ttl"] = \
+        tk.IntVar(value=configuration.overlay_ttl)
 
     nb.Label(frame, text="UI Settings", pady=10).grid(sticky=tk.W, padx=title_offset)
     ui_settings_checkboxes = [
@@ -139,13 +152,21 @@ def build_settings_ui(root: nb.Notebook) -> tk.Frame:
         nb.Checkbutton(frame, text="Display Sum-Row",
                        variable=__setting_changes["display_sum_row"]),
         nb.Checkbutton(frame, text="Display Summary-Row",
-                       variable=__setting_changes["display_ratio_and_cr_per_kill_row"]),
-        nb.Checkbutton(frame, text="Display: Use overlay",
-                       variable=__setting_changes["display_use_overlay"]),
+                       variable=__setting_changes["display_ratio_and_cr_per_kill_row"])
     ]
     for entry in ui_settings_checkboxes:
         entry.grid(columnspan=2, padx=checkbox_offset, sticky=tk.W)
-
+    
+    nb.Label(frame, text="Overlay", pady=10).grid(sticky=tk.W, padx=title_offset)
+    logger.debug(configuration.overlay_enabled)
+    logger.debug(configuration.overlay_ttl)
+    logger.debug(configuration.display_sum_row)
+    nb.Checkbutton(frame, text="Enable overlay", variable=__setting_changes["overlay_enabled"]).grid(padx=checkbox_offset, sticky=tk.W)
+    ttl_frame = nb.Frame(frame)
+    nb.Label(ttl_frame, text="Overlay TTL:").grid(column=0, row=0, sticky=tk.W)
+    nb.Entry(ttl_frame, textvariable=__setting_changes["overlay_ttl"]).grid(column=1, row=0, sticky=tk.W, padx=checkbox_offset)
+    ttl_frame.grid(sticky=tk.W, padx=checkbox_offset)
+    
     nb.Label(frame, text="Other", pady=10, padx=title_offset).grid(sticky=tk.W)
     nb.Checkbutton(frame, text="Check for Updates on Start", variable=__setting_changes["check_updates"])\
         .grid(columnspan=2, sticky=tk.W, padx=checkbox_offset)

--- a/massacre/massacre_settings.py
+++ b/massacre/massacre_settings.py
@@ -64,24 +64,6 @@ class Configuration:
         config.set(f"{self.plugin_name}.display_first_user_help", value)
     
     #######################################
-    @property
-    def overlay_enabled(self):
-        return config.get_bool(f"{self.plugin_name}.overlay_enabled", default=True)
-    
-    @overlay_enabled.setter
-    def overlay_enabled(self, value: bool):
-        config.set(f"{self.plugin_name}.overlay_enabled", value)
-    
-    #######################################
-    @property
-    def overlay_ttl(self):
-        return config.get_int(f"{self.plugin_name}.overlay_ttl", default=30)
-    
-    @overlay_ttl.setter
-    def overlay_ttl(self, value: int):
-        config.set(f"{self.plugin_name}.overlay_ttl", value)
-    
-    #######################################
     def __init__(self, plugin_name: str):
        self.plugin_name = plugin_name
        self.config_changed_listeners: list[Callable[[Configuration], None]] = []
@@ -143,10 +125,6 @@ def build_settings_ui(root: nb.Notebook) -> tk.Frame:
         tk.IntVar(value=configuration.display_sum_row)
     __setting_changes["display_ratio_and_cr_per_kill_row"] = \
         tk.IntVar(value=configuration.display_ratio_and_cr_per_kill_row)
-    __setting_changes["overlay_enabled"] = \
-        tk.IntVar(value=configuration.overlay_enabled)
-    __setting_changes["overlay_ttl"] = \
-        tk.IntVar(value=configuration.overlay_ttl)
 
     nb.Label(frame, text="UI Settings", pady=10).grid(sticky=tk.W, padx=title_offset)
     ui_settings_checkboxes = [
@@ -159,18 +137,7 @@ def build_settings_ui(root: nb.Notebook) -> tk.Frame:
     ]
     for entry in ui_settings_checkboxes:
         entry.grid(columnspan=2, padx=checkbox_offset, sticky=tk.W)
-    
-
-    #nb.Label(frame, text="Overlay", pady=10).grid(sticky=tk.W, padx=title_offset)
-    #logger.debug(configuration.overlay_enabled)
-    #logger.debug(configuration.overlay_ttl)
-    #logger.debug(configuration.display_sum_row)
-    #nb.Checkbutton(frame, text="Enable overlay", variable=__setting_changes["overlay_enabled"]).grid(padx=checkbox_offset, sticky=tk.W)
-    #ttl_frame = nb.Frame(frame)
-    #nb.Label(ttl_frame, text="Overlay TTL:").grid(column=0, row=0, sticky=tk.W)
-    #nb.Entry(ttl_frame, textvariable=__setting_changes["overlay_ttl"]).grid(column=1, row=0, sticky=tk.W, padx=checkbox_offset)
-    #ttl_frame.grid(sticky=tk.W, padx=checkbox_offset)
-    
+ 
     nb.Label(frame, text="Other", pady=10, padx=title_offset).grid(sticky=tk.W)
     nb.Checkbutton(frame, text="Check for Updates on Start", variable=__setting_changes["check_updates"])\
         .grid(columnspan=2, sticky=tk.W, padx=checkbox_offset)

--- a/massacre/massacre_settings.py
+++ b/massacre/massacre_settings.py
@@ -63,6 +63,16 @@ class Configuration:
     def display_first_user_help(self, value: bool):
         config.set(f"{self.plugin_name}.display_first_user_help", value)
 
+    #######################################
+    @property
+    def display_use_overlay(self):
+        return config.get_bool(f"{self.plugin_name}.display_use_overlay", default=True)
+
+    @display_use_overlay.setter
+    def display_use_overlay(self, value: bool):
+        config.set(f"{self.plugin_name}.display_use_overlay", value)
+
+    #######################################
     def __init__(self):
         self.plugin_name = os.path.basename(os.path.dirname(__file__))
         self.config_changed_listeners: list[Callable[[Configuration], None]] = []
@@ -78,6 +88,8 @@ class Configuration:
             self.display_sum_row = data["display_sum_row"].get()
         if "display_ratio_and_cr_per_kill_row" in keys:
             self.display_ratio_and_cr_per_kill_row = data["display_ratio_and_cr_per_kill_row"].get()
+        if "display_use_overlay" in keys:
+            self.display_use_overlay = data["display_use_overlay"].get()
 
         for listener in self.config_changed_listeners:
             listener(self)
@@ -117,6 +129,8 @@ def build_settings_ui(root: nb.Notebook) -> tk.Frame:
         tk.IntVar(value=configuration.display_sum_row)
     __setting_changes["display_ratio_and_cr_per_kill_row"] = \
         tk.IntVar(value=configuration.display_ratio_and_cr_per_kill_row)
+    __setting_changes["display_use_overlay"] = \
+        tk.IntVar(value=configuration.display_use_overlay)
 
     nb.Label(frame, text="UI Settings", pady=10).grid(sticky=tk.W, padx=title_offset)
     ui_settings_checkboxes = [
@@ -125,7 +139,9 @@ def build_settings_ui(root: nb.Notebook) -> tk.Frame:
         nb.Checkbutton(frame, text="Display Sum-Row",
                        variable=__setting_changes["display_sum_row"]),
         nb.Checkbutton(frame, text="Display Summary-Row",
-                       variable=__setting_changes["display_ratio_and_cr_per_kill_row"])
+                       variable=__setting_changes["display_ratio_and_cr_per_kill_row"]),
+        nb.Checkbutton(frame, text="Display: Use overlay",
+                       variable=__setting_changes["display_use_overlay"]),
     ]
     for entry in ui_settings_checkboxes:
         entry.grid(columnspan=2, padx=checkbox_offset, sticky=tk.W)

--- a/massacre/overlay.py
+++ b/massacre/overlay.py
@@ -1,0 +1,197 @@
+import os
+from typing import Optional
+
+import massacre.massacre_settings
+from massacre.massacre_mission_state import massacre_mission_listeners, MassacreMission
+from massacre.massacre_settings import Configuration
+from massacre.logger_factory import logger
+from massacre.version_check import open_download_page
+from theme import theme
+
+class MassacreMissionData:
+    """
+    Creates a "data-view" for the OVERLAY from all massacre missions. Will be used to create a table-like OVERLAY
+    Done to split the calculations from the OVERLAY.
+    """
+    def __init__(self, massacre_state: dict[int, MassacreMission]):
+        self.warnings: list[str] = []
+        # Faction -> <Count, Reward, ShareableReward, DistanceToMax>
+        target_factions: list[str] = []
+        target_types: list[str] = []
+        target_systems: list[str] = []
+        self.faction_to_count_lookup: dict[str, tuple[int, int, int]] = {}
+        self.stack_height = 0
+        # This is the second-highest value. This is used to display the second-largest value in the delta-Field using
+        # a negative.
+        self.before_stack_height = 0
+        self.target_sum = 0
+        self.reward = 0
+        self.shareable_reward = 0
+
+        for mission in massacre_state.values():
+            mission_giver = mission.source_faction
+
+            if mission_giver not in self.faction_to_count_lookup.keys():
+                self.faction_to_count_lookup[mission_giver] = 0, 0, 0
+
+            kill_count, reward, shareable_reward = self.faction_to_count_lookup[mission_giver]
+            kill_count += mission.count
+            self.target_sum += mission.count
+            reward += mission.reward
+            if mission.is_wing:
+                shareable_reward += mission.reward
+
+            self.faction_to_count_lookup[mission_giver] = kill_count, reward, shareable_reward
+
+            self.shareable_reward += shareable_reward
+            self.reward += reward
+
+            if mission.target_faction not in target_factions:
+                target_factions.append(mission.target_faction)
+
+            if mission.target_type not in target_types:
+                target_types.append(mission.target_type)
+
+            if mission.target_system not in target_systems:
+                target_systems.append(mission.target_system)
+
+            if kill_count > self.stack_height:
+                self.stack_height = kill_count
+
+        # Check for Warnings
+        if len(target_factions) > 1:
+            self.warnings.append(f"Multiple Target Factions: {', '.join(target_factions)}!")
+        if len(target_types) > 1:
+            self.warnings.append(f"Multiple Target Types: {', '.join(target_types)}!")
+        if len(target_systems) > 1:
+            self.warnings.append(f"Multiple Target Systems: {', '.join(target_systems)}!")
+
+        # Calculate before_stack_height
+        for count, _a, _b in self.faction_to_count_lookup.values():
+            if count > self.before_stack_height and count != self.stack_height:
+                self.before_stack_height = count
+        if self.before_stack_height == 0:  # No other elements. All at max value.
+            self.before_stack_height = self.stack_height
+
+
+class GridOverlaySettings:
+    """
+    Subset of the entire Configuration that focuses on which information is displayed
+    """
+    def __init__(self, config: Configuration):
+        self.use_overlay = config.display_use_overlay
+
+
+def __display_data_header(settings: GridOverlaySettings):
+    """
+    Display the Labels of the Table
+    """
+
+    overlay_elements = ['Kills', 'Reward (Wing)', f'{"Faction":15}']
+
+    return overlay_elements
+
+
+def __display_row(faction: str, data: tuple[int, int, int], max_count: int,
+                  settings: GridOverlaySettings, second_largest_count: int):
+    """
+    Draw one Data-Row for the Table
+    """
+    count, reward, shareable_reward = data
+    reward_str = "{:.1f}".format(float(reward) / 1_000_000)
+    shareable_reward_str = "{:.1f}".format(float(shareable_reward) / 1_000_000)
+    whole_reward_str = f'{reward_str} ({shareable_reward_str})'
+    overlay_elements = [f'{count:4}', f'{whole_reward_str:{len("Reward (Wing)")}}', f'{faction:15}']
+
+    return overlay_elements
+
+def __display_sum(data: MassacreMissionData, _settings: GridOverlaySettings):
+    """
+    Display the Sum-Row containing the Reward-Sum and the amount of Kills required.
+    """
+    label = "Sum"
+    kill_sum = data.stack_height
+    reward_sum_normal = "{:.1f}".format(float(data.reward) / 1_000_000)
+    reward_sum_wing = "{:.1f}".format(float(data.shareable_reward) / 1_000_000)
+    reward_sum = f"{reward_sum_normal} ({reward_sum_wing})"
+    return [f'{kill_sum:4}', f'{reward_sum:{len("Reward (Wing)")}}', f'{"Sum":15}']
+
+def _display_data(data: MassacreMissionData, settings: GridOverlaySettings):
+    lines = []
+    lines.append('|'.join(__display_data_header(overlay, settings)))
+    for faction in sorted(data.faction_to_count_lookup.keys()):
+        lines.append('|'.join(__display_row(overlay, faction, data.faction_to_count_lookup[faction], data.stack_height, settings, data.before_stack_height)))
+
+    lines.append('|'.join(__display_sum(overlay, data, settings)))
+
+    lines.extend(data.warnings)
+
+    return lines
+
+
+def _display_waiting_for_missions():
+    return ["Massacre Plugin is ready."]
+
+
+class Overlay:
+    def _create_overlay(self):
+        self.__overlay = None
+        if self.__settings.use_overlay:
+            try:
+                import EDMCOverlay
+                self.__overlay = EDMCOverlay.Overlay()
+            except ModuleNotFoundError:
+                logger.warning("Overlay library could not be loaded.")
+                
+    def __init__(self):
+        self.__data: Optional[MassacreMissionData] = None
+        self.__settings: GridOverlaySettings = GridOverlaySettings(massacre.massacre_settings.configuration)
+        self._create_overlay()
+        massacre.massacre_settings.configuration.config_changed_listeners.append(self.rebuild_settings)
+                
+    def __bool__(self):
+        return self.__overlay != None
+
+    def rebuild_settings(self, config: Configuration):
+        self.__settings = GridOverlaySettings(config)
+        self._create_overlay()
+        self.update_overlay()
+    
+    def notify_about_new_massacre_mission_state(self, data: Optional[MassacreMissionData]):
+        self.__data = data
+        self.update_overlay()
+
+    def notify_about_settings_changed(self):
+        self.__settings: GridOverlaySettings = GridOverlaySettings(massacre.massacre_settings.configuration)
+        self._create_overlay()
+        self.update_overlay()
+
+    def update_overlay(self):
+        if self.__overlay is None:
+            logger.warning("Overlay was not yet set. Overlay was not updated.")
+            return
+
+        logger.info("Updating Overlay...")
+
+        lines = []
+        if self.__data is None:
+            pass
+        elif self.__data.target_sum == 0:
+            lines = _display_waiting_for_missions()
+        else:
+            lines = _display_data(self.__data, self.__settings)
+
+        if lines:
+            self.__overlay.send_message('massacre-update', os.linesep.join(lines), 'yellow', 0, 0, ttl=30)
+
+        logger.info("Overlay Update done")
+
+overlay = Overlay()
+
+
+def handle_new_massacre_mission_state(data: dict[int, MassacreMission]):
+    data_view = MassacreMissionData(data)
+    overlay.notify_about_new_massacre_mission_state(data_view)
+
+
+massacre_mission_listeners.append(handle_new_massacre_mission_state)

--- a/massacre/overlay.py
+++ b/massacre/overlay.py
@@ -25,16 +25,15 @@ def __display_data_header(settings: GridOverlaySettings):
     return overlay_elements
 
 
-def __display_row(faction: str, data: tuple[int, int, int], max_count: int,
+def __display_row(faction: str, data: MassacreMissionData.FactionState, max_count: int,
                   settings: GridOverlaySettings, second_largest_count: int):
     """
     Draw one Data-Row for the Table
     """
-    count, reward, shareable_reward = data
-    reward_str = "{:.1f}".format(float(reward) / 1_000_000)
-    shareable_reward_str = "{:.1f}".format(float(shareable_reward) / 1_000_000)
+    reward_str = "{:.1f}".format(float(data.reward) / 1_000_000)
+    shareable_reward_str = "{:.1f}".format(float(data.shareable_reward) / 1_000_000)
     whole_reward_str = f'{reward_str} ({shareable_reward_str})'
-    overlay_elements = [f'{count:4}', f'{whole_reward_str:{len("Reward (Wing)")}}', f'{faction:15}']
+    overlay_elements = [f'{data.killcount:5}', f'{whole_reward_str:{len("Reward (Wing)")}}', f'{faction:15}']
 
     return overlay_elements
 
@@ -47,15 +46,16 @@ def __display_sum(data: MassacreMissionData, _settings: GridOverlaySettings):
     reward_sum_normal = "{:.1f}".format(float(data.reward) / 1_000_000)
     reward_sum_wing = "{:.1f}".format(float(data.shareable_reward) / 1_000_000)
     reward_sum = f"{reward_sum_normal} ({reward_sum_wing})"
-    return [f'{kill_sum:4}', f'{reward_sum:{len("Reward (Wing)")}}', f'{"Sum":15}']
+    return [f'{kill_sum:5}', f'{reward_sum:{len("Reward (Wing)")}}', f'{"Sum":15}']
 
 def _display_data(data: MassacreMissionData, settings: GridOverlaySettings):
     lines = []
-    lines.append('|'.join(__display_data_header(overlay, settings)))
-    for faction in sorted(data.faction_to_count_lookup.keys()):
-        lines.append('|'.join(__display_row(overlay, faction, data.faction_to_count_lookup[faction], data.stack_height, settings, data.before_stack_height)))
+    lines.append('|'.join(__display_data_header(settings)))
 
-    lines.append('|'.join(__display_sum(overlay, data, settings)))
+    lines.append('|'.join(__display_sum(data, settings)))
+
+    for faction in sorted(data.faction_to_count_lookup.keys()):
+        lines.append('|'.join(__display_row(faction, data.faction_to_count_lookup[faction], data.stack_height, settings, data.before_stack_height)))
 
     lines.extend(data.warnings)
 
@@ -71,8 +71,8 @@ class Overlay:
         self.__overlay = None
         if self.__settings.use_overlay:
             try:
-                import EDMCOverlay
-                self.__overlay = EDMCOverlay.Overlay()
+                import edmcoverlay
+                self.__overlay = edmcoverlay.Overlay()
             except ModuleNotFoundError:
                 logger.warning("Overlay library could not be loaded.")
                 
@@ -118,7 +118,7 @@ class Overlay:
         for line in lines:
             self.__overlay.send_message(f'massacre-line-{line_y}',
                                         line,
-                                        'yellow',
+                                        'green',
                                         0,
                                         line_y,
                                         ttl=self.__settings.overlay_ttl)

--- a/massacre/overlay.py
+++ b/massacre/overlay.py
@@ -1,78 +1,10 @@
-import os
 from typing import Optional
 
 import massacre.massacre_settings
 from massacre.massacre_mission_state import massacre_mission_listeners, MassacreMission
 from massacre.massacre_settings import Configuration
 from massacre.logger_factory import logger
-from massacre.version_check import open_download_page
-from theme import theme
-
-class MassacreMissionData:
-    """
-    Creates a "data-view" for the OVERLAY from all massacre missions. Will be used to create a table-like OVERLAY
-    Done to split the calculations from the OVERLAY.
-    """
-    def __init__(self, massacre_state: dict[int, MassacreMission]):
-        self.warnings: list[str] = []
-        # Faction -> <Count, Reward, ShareableReward, DistanceToMax>
-        target_factions: list[str] = []
-        target_types: list[str] = []
-        target_systems: list[str] = []
-        self.faction_to_count_lookup: dict[str, tuple[int, int, int]] = {}
-        self.stack_height = 0
-        # This is the second-highest value. This is used to display the second-largest value in the delta-Field using
-        # a negative.
-        self.before_stack_height = 0
-        self.target_sum = 0
-        self.reward = 0
-        self.shareable_reward = 0
-
-        for mission in massacre_state.values():
-            mission_giver = mission.source_faction
-
-            if mission_giver not in self.faction_to_count_lookup.keys():
-                self.faction_to_count_lookup[mission_giver] = 0, 0, 0
-
-            kill_count, reward, shareable_reward = self.faction_to_count_lookup[mission_giver]
-            kill_count += mission.count
-            self.target_sum += mission.count
-            reward += mission.reward
-            if mission.is_wing:
-                shareable_reward += mission.reward
-
-            self.faction_to_count_lookup[mission_giver] = kill_count, reward, shareable_reward
-
-            self.shareable_reward += shareable_reward
-            self.reward += reward
-
-            if mission.target_faction not in target_factions:
-                target_factions.append(mission.target_faction)
-
-            if mission.target_type not in target_types:
-                target_types.append(mission.target_type)
-
-            if mission.target_system not in target_systems:
-                target_systems.append(mission.target_system)
-
-            if kill_count > self.stack_height:
-                self.stack_height = kill_count
-
-        # Check for Warnings
-        if len(target_factions) > 1:
-            self.warnings.append(f"Multiple Target Factions: {', '.join(target_factions)}!")
-        if len(target_types) > 1:
-            self.warnings.append(f"Multiple Target Types: {', '.join(target_types)}!")
-        if len(target_systems) > 1:
-            self.warnings.append(f"Multiple Target Systems: {', '.join(target_systems)}!")
-
-        # Calculate before_stack_height
-        for count, _a, _b in self.faction_to_count_lookup.values():
-            if count > self.before_stack_height and count != self.stack_height:
-                self.before_stack_height = count
-        if self.before_stack_height == 0:  # No other elements. All at max value.
-            self.before_stack_height = self.stack_height
-
+from massacre.ui import MassacreMissionData
 
 class GridOverlaySettings:
     """

--- a/massacre/overlay.py
+++ b/massacre/overlay.py
@@ -79,7 +79,8 @@ class GridOverlaySettings:
     Subset of the entire Configuration that focuses on which information is displayed
     """
     def __init__(self, config: Configuration):
-        self.use_overlay = config.display_use_overlay
+        self.use_overlay = config.overlay_enabled
+        self.overlay_ttl = config.overlay_ttl
 
 
 def __display_data_header(settings: GridOverlaySettings):
@@ -181,9 +182,16 @@ class Overlay:
         else:
             lines = _display_data(self.__data, self.__settings)
 
-        if lines:
-            self.__overlay.send_message('massacre-update', os.linesep.join(lines), 'yellow', 0, 0, ttl=30)
-
+        line_y = 0
+        for line in lines:
+            self.__overlay.send_message(f'massacre-line-{line_y}',
+                                        line,
+                                        'yellow',
+                                        0,
+                                        line_y,
+                                        ttl=self.__settings.overlay_ttl)
+            line_y+=20
+        
         logger.info("Overlay Update done")
 
 overlay = Overlay()


### PR DESCRIPTION
I wanted to print the stack in EDMC Overlay so I wrote a few lines.

I used [edmcoverlay2 for linux](https://github.com/sersorrel/edmcoverlay2) but it should be compatible with the [EDMCOverlay](https://github.com/inorton/EDMCOverlay).

If the code will not be able to import edmcoverlay (low case for compatibility with [EDR](https://github.com/lekeno/edr)) the overlay object will not be updating so it should not break even if user checks "use overlay" in the settings when not having an overlay installed.

Could you please take a look?